### PR TITLE
[#37] Spring Data JPA 설정 및 사용(User)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,14 @@ jobs:
       run: chmod +x gradlew
     - name: Test with Gradle
       run: ./gradlew test
+    - name: Setup MySQL
+      uses: samin/mysql-action@v1
+      with:
+        host port: 3307
+        container port: 3306
+        character set server: 'utf8'
+        mysql version: '5.7'
+        mysql database: 'jagoga_db'
+        mysql root password: ${{ secrets.RootPassword }}
+        mysql user: 'admin'
+        mysql password: ${{ secrets.DatabasePassword }}  

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,15 +13,6 @@ jobs:
   test: 
     runs-on: ubuntu-latest 
     steps:
-    - uses: actions/checkout@v2 
-    - name: Set up JDK 11 
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Test with Gradle
-      run: ./gradlew test
     - name: Setup MySQL
       uses: samin/mysql-action@v1
       with:
@@ -33,3 +24,12 @@ jobs:
         mysql root password: ${{ secrets.RootPassword }}
         mysql user: 'admin'
         mysql password: ${{ secrets.DatabasePassword }}  
+    - uses: actions/checkout@v2 
+    - name: Set up JDK 11 
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11 
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Test with Gradle
+      run: ./gradlew test

--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ out/
 ### ignore properties file
 application-dev.properties
 application-prod.properties
-application.yml

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 ### ignore properties file
 application-dev.properties
 application-prod.properties
+application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.0'
 	implementation 'javax.xml.bind:jaxb-api:2.1'
 	implementation 'mysql:mysql-connector-java'
+	runtimeOnly 'com.h2database:h2'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -13,17 +13,20 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.7'
 	implementation group: 'org.mindrot', name: 'jbcrypt', version: '0.4'
 	implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.8'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-    testCompileOnly 'org.projectlombok:lombok'
-    testAnnotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.0'
 	implementation 'javax.xml.bind:jaxb-api:2.1'
+	implementation 'mysql:mysql-connector-java'
 }
 
 test {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+
+services:
+  mysql:
+    image: mysql:5.7
+    volumes:
+      - ./jagoga-mysql-volume:/var/lib/mysql
+    restart: always
+    container_name: mysql_db
+    environment:
+      MYSQL_ROOT_PASSWORD: jagogaqwer1234
+      MYSQL_DATABASE: jagoga_db
+      MYSQL_USER: admin
+      MYSQL_PASSWORD: jagogaqwer1234
+    ports:
+      - "3307:3306"

--- a/sql/users.sql
+++ b/sql/users.sql
@@ -1,0 +1,11 @@
+create table USERS (
+    user_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255),
+    name VARCHAR(30),
+    password VARCHAR(30),
+    phone VARCHAR(20),
+    role VARCHAR(10),
+    created_at DATETIME,
+    updated_at DATETIME,
+    UNIQUE INDEX (email)
+) engine=InnoDB default character set = utf8;

--- a/src/main/java/com/project/jagoga/JagogaApplication.java
+++ b/src/main/java/com/project/jagoga/JagogaApplication.java
@@ -2,7 +2,9 @@ package com.project.jagoga;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class JagogaApplication {
 

--- a/src/main/java/com/project/jagoga/user/application/impl/UserServiceImpl.java
+++ b/src/main/java/com/project/jagoga/user/application/impl/UserServiceImpl.java
@@ -1,20 +1,20 @@
 package com.project.jagoga.user.application.impl;
 
 import com.project.jagoga.exception.user.DuplicatedUserException;
-import com.project.jagoga.exception.user.ForbiddenException;
 import com.project.jagoga.exception.user.NotFoundUserException;
 import com.project.jagoga.user.application.UserService;
 import com.project.jagoga.user.domain.AuthUser;
 import com.project.jagoga.user.domain.PasswordEncoder;
-import com.project.jagoga.user.domain.Role;
 import com.project.jagoga.user.domain.User;
 import com.project.jagoga.user.domain.UserRepository;
 import com.project.jagoga.user.presentation.dto.request.UserCreateRequestDto;
 import com.project.jagoga.user.presentation.dto.request.UserUpdateRequestDto;
 import com.project.jagoga.utils.VerificationUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
@@ -37,10 +37,10 @@ public class UserServiceImpl implements UserService {
     public User updateUser(long id, UserUpdateRequestDto userUpdateRequestDto, AuthUser loginUser) {
         VerificationUtils.verifyPermission(loginUser, id);
         User user = userRepository.findById(id).orElseThrow(NotFoundUserException::new);
-        User updateUser = user.updateUser(userUpdateRequestDto.getName(),
+        user.updateUser(userUpdateRequestDto.getName(),
             passwordEncoder.encrypt(userUpdateRequestDto.getPassword()),
             userUpdateRequestDto.getPhone());
-        return userRepository.update(updateUser);
+        return user;
     }
 
     private void validateDuplicatedUser(User user) {

--- a/src/main/java/com/project/jagoga/user/domain/User.java
+++ b/src/main/java/com/project/jagoga/user/domain/User.java
@@ -1,20 +1,36 @@
 package com.project.jagoga.user.domain;
 
-import java.time.LocalDateTime;
+import com.project.jagoga.utils.BaseTimeEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.util.Assert;
 
+@Entity
+@Table(name = "USERS")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class User {
+public class User extends BaseTimeEntity {
 
+    @Id
+    @GeneratedValue
+    @Column(name = "user_id")
     private Long id;
+
     private String email;
     private String name;
     private String password;
     private String phone;
+
+    @Enumerated(EnumType.STRING)
     private Role role;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
     public void setId(Long id) {
         this.id = id;
@@ -24,8 +40,10 @@ public class User {
         this.password = password;
     }
 
-    public User updateUser(String name, String password, String phone) {
-        return new User(this.id, this.email, name, password, phone, this.role);
+    public void updateUser(String name, String password, String phone) {
+        this.name = name;
+        this.password = password;
+        this.phone = phone;
     }
 
     public static User createInstance(String email, String name, String password, String phone) {

--- a/src/main/java/com/project/jagoga/user/infrastructure/JpaUserRepository.java
+++ b/src/main/java/com/project/jagoga/user/infrastructure/JpaUserRepository.java
@@ -1,0 +1,12 @@
+package com.project.jagoga.user.infrastructure;
+
+import com.project.jagoga.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaUserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsUserByEmail(String email);
+}

--- a/src/main/java/com/project/jagoga/user/infrastructure/MemoryUserRepository.java
+++ b/src/main/java/com/project/jagoga/user/infrastructure/MemoryUserRepository.java
@@ -1,16 +1,12 @@
 package com.project.jagoga.user.infrastructure;
 
-import com.project.jagoga.accommodation.domain.Accommodation;
 import com.project.jagoga.user.domain.User;
 import com.project.jagoga.user.domain.UserRepository;
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.stereotype.Repository;
-
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.lang3.StringUtils;
 
-@Repository
 public class MemoryUserRepository implements UserRepository {
 
     private static ConcurrentHashMap<Long, User> userMap = new ConcurrentHashMap<>();
@@ -42,7 +38,7 @@ public class MemoryUserRepository implements UserRepository {
     @Override
     public boolean existsByEmail(String email) {
         return userMap.values().stream()
-                .anyMatch(user -> StringUtils.equals(user.getEmail(), email));
+            .anyMatch(user -> StringUtils.equals(user.getEmail(), email));
     }
 
     @Override

--- a/src/main/java/com/project/jagoga/user/infrastructure/UserRepositoryAdapter.java
+++ b/src/main/java/com/project/jagoga/user/infrastructure/UserRepositoryAdapter.java
@@ -1,0 +1,44 @@
+package com.project.jagoga.user.infrastructure;
+
+import com.project.jagoga.user.domain.User;
+import com.project.jagoga.user.domain.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserRepositoryAdapter implements UserRepository {
+
+    private final JpaUserRepository jpaUserRepository;
+
+    @Override
+    public User save(User user) {
+        return jpaUserRepository.save(user);
+    }
+
+    @Override
+    public User update(User user) {
+        return jpaUserRepository.save(user);
+    }
+
+    @Override
+    public Optional<User> findById(Long userId) {
+        return jpaUserRepository.findById(userId);
+    }
+
+    @Override
+    public Optional<User> getByEmail(String email) {
+        return jpaUserRepository.findByEmail(email);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return jpaUserRepository.existsUserByEmail(email);
+    }
+
+    @Override
+    public void deleteAll() {
+        jpaUserRepository.deleteAll();
+    }
+}

--- a/src/main/java/com/project/jagoga/utils/BaseTimeEntity.java
+++ b/src/main/java/com/project/jagoga/utils/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.project.jagoga.utils;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-# github action build시 오류로 인한 임시 설정(secret key 미존재)
-jwt.secret=publicsecretkey

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3307/jagoga_db?serverTimezone=UTC&characterEncoding=UTF-8
+    username: admin
+    password: jagogaqwer1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        # show_sql: true
+        format_sql: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+
+jwt:
+  secret: publicsecretkey

--- a/src/test/java/com/project/jagoga/user/application/impl/UserServiceImplTest.java
+++ b/src/test/java/com/project/jagoga/user/application/impl/UserServiceImplTest.java
@@ -1,23 +1,27 @@
 package com.project.jagoga.user.application.impl;
 
+import static org.junit.jupiter.api.Assertions.*;
 import com.project.jagoga.exception.user.DuplicatedUserException;
 import com.project.jagoga.exception.user.ForbiddenException;
-import com.project.jagoga.user.domain.*;
-import com.project.jagoga.user.infrastructure.BCryptPasswordEncoder;
-import com.project.jagoga.user.infrastructure.MemoryUserRepository;
+import com.project.jagoga.user.application.UserService;
+import com.project.jagoga.user.domain.AuthUser;
+import com.project.jagoga.user.domain.Role;
+import com.project.jagoga.user.domain.User;
 import com.project.jagoga.user.presentation.dto.request.UserCreateRequestDto;
 import com.project.jagoga.user.presentation.dto.request.UserUpdateRequestDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+@SpringBootTest
+@Transactional
 class UserServiceImplTest {
 
-    UserRepository userRepository = new MemoryUserRepository();
-    PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-    UserServiceImpl userService = new UserServiceImpl(userRepository, passwordEncoder);
+    @Autowired
+    UserService userService;
 
     String email;
     String name;
@@ -43,8 +47,6 @@ class UserServiceImplTest {
         // then
         assertNotEquals(password, user.getPassword());
         assertEquals(Role.BASIC, user.getRole());
-
-        userRepository.deleteAll();
     }
 
     @Test
@@ -54,12 +56,11 @@ class UserServiceImplTest {
         userService.signUp(userCreateRequestDto);
 
         // when
-        Exception exception = assertThrows(DuplicatedUserException.class, () -> userService.signUp(userCreateRequestDto));
+        Exception exception =
+            assertThrows(DuplicatedUserException.class, () -> userService.signUp(userCreateRequestDto));
 
         // then
         assertEquals("이미 존재하는 회원입니다", exception.getMessage());
-
-        userRepository.deleteAll();
     }
 
     @Test
@@ -67,20 +68,19 @@ class UserServiceImplTest {
     public void updateUser() {
         // given
         User user = userService.signUp(userCreateRequestDto);
-        UserUpdateRequestDto userUpdateRequestDto = new UserUpdateRequestDto("updatename", "!@#ASkdkdkd", "010-4321-4321");
+        UserUpdateRequestDto userUpdateRequestDto =
+            new UserUpdateRequestDto("updatename", "!@#ASkdkdkd", "010-4321-4321");
         AuthUser authUser = AuthUser.createInstance(user.getId(), user.getEmail(), user.getRole());
 
         // when
         User updateUser = userService.updateUser(user.getId(), userUpdateRequestDto, authUser);
 
         // then
-        assertEquals(user.getEmail(), updateUser.getEmail());
-        assertEquals(user.getRole(), updateUser.getRole());
-        assertNotEquals(user.getName(), updateUser.getName());
-        assertNotEquals(user.getPassword(), updateUser.getPassword());
-        assertNotEquals(user.getPhone(), updateUser.getPhone());
-
-        userRepository.deleteAll();
+        assertEquals(email, updateUser.getEmail());
+        assertEquals(Role.BASIC, updateUser.getRole());
+        assertNotEquals(name, updateUser.getName());
+        assertNotEquals(password, updateUser.getPassword());
+        assertNotEquals(phone, updateUser.getPhone());
     }
 
     @Test
@@ -88,19 +88,19 @@ class UserServiceImplTest {
     public void updateOtherUser() {
         // given
         User user = userService.signUp(userCreateRequestDto);
-        UserUpdateRequestDto userUpdateRequestDto = new UserUpdateRequestDto("updatename", "!@#ASkdkdkd", "010-4321-4321");
+        UserUpdateRequestDto userUpdateRequestDto =
+            new UserUpdateRequestDto("updatename", "!@#ASkdkdkd", "010-4321-4321");
 
         long otherUserId = 123L;
         assertNotEquals(user.getId(), otherUserId);
         AuthUser authUser = AuthUser.createInstance(otherUserId, user.getEmail(), user.getRole());
 
         // when
-        Exception exception = assertThrows(ForbiddenException.class, () -> userService.updateUser(user.getId(), userUpdateRequestDto, authUser));
+        Exception exception = assertThrows(ForbiddenException.class,
+            () -> userService.updateUser(user.getId(), userUpdateRequestDto, authUser));
 
         // then
         assertEquals("권한이 없는 사용자입니다", exception.getMessage());
-
-        userRepository.deleteAll();
     }
 
     @Test
@@ -108,7 +108,8 @@ class UserServiceImplTest {
     public void updateOtherUserByAdmin() {
         // given
         User user = userService.signUp(userCreateRequestDto);
-        UserUpdateRequestDto userUpdateRequestDto = new UserUpdateRequestDto("updatename", "!@#ASkdkdkd", "010-4321-4321");
+        UserUpdateRequestDto userUpdateRequestDto =
+            new UserUpdateRequestDto("updatename", "!@#ASkdkdkd", "010-4321-4321");
 
         long otherUserId = 123L;
         assertNotEquals(user.getId(), otherUserId);
@@ -118,12 +119,10 @@ class UserServiceImplTest {
         User updateUser = userService.updateUser(user.getId(), userUpdateRequestDto, authUser);
 
         // then
-        assertEquals(user.getEmail(), updateUser.getEmail());
-        assertEquals(user.getRole(), updateUser.getRole());
-        assertNotEquals(user.getName(), updateUser.getName());
-        assertNotEquals(user.getPassword(), updateUser.getPassword());
-        assertNotEquals(user.getPhone(), updateUser.getPhone());
-
-        userRepository.deleteAll();
+        assertEquals(email, updateUser.getEmail());
+        assertEquals(Role.BASIC, updateUser.getRole());
+        assertNotEquals(name, updateUser.getName());
+        assertNotEquals(password, updateUser.getPassword());
+        assertNotEquals(phone, updateUser.getPhone());
     }
 }

--- a/src/test/java/com/project/jagoga/user/presentation/controller/UserControllerTest.java
+++ b/src/test/java/com/project/jagoga/user/presentation/controller/UserControllerTest.java
@@ -9,6 +9,7 @@ import com.project.jagoga.user.presentation.dto.request.LoginRequestDto;
 import com.project.jagoga.user.presentation.dto.request.UserCreateRequestDto;
 import com.project.jagoga.user.presentation.dto.request.UserUpdateRequestDto;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -62,6 +63,11 @@ class UserControllerTest {
         loginRequestDto = new LoginRequestDto(email, password);
     }
 
+    @AfterEach
+    public void after() {
+        userRepository.deleteAll();
+    }
+
     @Test
     @DisplayName("사용자 로그인 테스트")
     public void login() throws Exception {
@@ -76,8 +82,6 @@ class UserControllerTest {
                 .content(loginJson))
                 .andExpect(status().isOk())
                 .andExpect((ResultMatcher) content().string(Matchers.containsString("accessToken")));
-
-        userRepository.deleteAll();
     }
 
     @Test
@@ -87,7 +91,8 @@ class UserControllerTest {
         User user = userService.signUp(userCreateRequestDto);
         String token = authentication.login(loginRequestDto);
 
-        UserUpdateRequestDto userUpdateRequestDto = new UserUpdateRequestDto("updateName", "@abcdefAd", "010-4321-4321");
+        UserUpdateRequestDto userUpdateRequestDto =
+            new UserUpdateRequestDto("updateName", "@abcdefAd", "010-4321-4321");
         String updateUserJson = objectMapper.writeValueAsString(userUpdateRequestDto);
 
         // when then
@@ -95,8 +100,6 @@ class UserControllerTest {
                 .header(HttpHeaders.AUTHORIZATION, token)
                 .content(updateUserJson))
                 .andExpect(status().isOk());
-
-        userRepository.deleteAll();
     }
 
     @Test
@@ -105,14 +108,13 @@ class UserControllerTest {
         // given
         User user = userService.signUp(userCreateRequestDto);
 
-        UserUpdateRequestDto userUpdateRequestDto = new UserUpdateRequestDto("updateName", "@abcdefdAS", "010-4321-4321");
+        UserUpdateRequestDto userUpdateRequestDto =
+            new UserUpdateRequestDto("updateName", "@abcdefdAS", "010-4321-4321");
         String updateUserJson = objectMapper.writeValueAsString(userUpdateRequestDto);
 
         // when then
         mockMvc.perform(put("/api/users/" + user.getId()).contentType(MediaType.APPLICATION_JSON)
                 .content(updateUserJson))
                 .andExpect(status().isUnauthorized());
-
-        userRepository.deleteAll();
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug
+  org.hibernate.type: trace
+
+jwt:
+  secret: testsecretkey


### PR DESCRIPTION
## 상세 내용
* User 관련 `Spring Data JPA` 설정 및 사용 
MemoryUserRepository → UserRepositoryAdapter 
스프링 데이터 JPA가 제공하는 `JpaRepository 인터페이스`는 기존에 생성한 `UserRepository 인터페이스`와 메서드 시그니처가 다르다는 문제점이 발생하여 서로 다른 두 인터페이스가 같은 형식 아래 작동하도록 `어댑터 패턴`을 적용하였습니다.

* JPA Auditing 
JPA Auditing을 활용하여 최초 생성일, 마지막 수정일을 자동으로 저장되도록 하였습니다.

* TEST
Service와 Repository 간의 의존도가 높다고 생각하여 Service 레이어 Test시 Repository를 사용하였습니다. 
JPA Repository 구현체를 주입받기 위해 @SpringBootTest로 진행하였습니다. 

## Issue
Github Action 테스트 코드 실패
데이터베이스 때문..? 알아보기,,