### PR TITLE
[#45] flyway 의존성 및 스크립트 파일 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'javax.xml.bind:jaxb-api:2.1'
 	implementation 'mysql:mysql-connector-java'
 	runtimeOnly 'com.h2database:h2'
+	implementation 'org.flywaydb:flyway-core:7.15.0'
 }
 
 test {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
         # show_sql: true
         format_sql: true
 
+spring.flyway:
+  baselineOnMigrate: true
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 상세 내용
기존 테이블 정보가 존재하기 때문에 빈 스크립트 파일 생성하였습니다.

## 참고사항
스키마가 변경시 현 버전보다 높은 버전의 스크립트 파일을
`src/main/resources/db/migration` 하위 경로에 추가해야 합니다.