### PR TITLE
[#66] AccommodationRequestDto의 ownerId 필드 삭제

### DIFF
--- a/src/main/java/com/project/jagoga/accommodation/application/AccommodationService.java
+++ b/src/main/java/com/project/jagoga/accommodation/application/AccommodationService.java
@@ -1,32 +1,27 @@
 package com.project.jagoga.accommodation.application;
 
+import com.project.jagoga.accommodation.domain.Accommodation;
+import com.project.jagoga.accommodation.domain.AccommodationRepository;
 import com.project.jagoga.accommodation.presentation.dto.AccommodationRequestDto;
 import com.project.jagoga.exception.accommodation.DuplicatedAccommodationException;
 import com.project.jagoga.exception.accommodation.NotExistAccommodationException;
-import com.project.jagoga.accommodation.domain.Accommodation;
-import com.project.jagoga.accommodation.domain.AccommodationRepository;
 import com.project.jagoga.user.domain.AuthUser;
-import com.project.jagoga.user.domain.User;
-import com.project.jagoga.user.domain.UserRepository;
 import com.project.jagoga.utils.VerificationUtils;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class AccommodationService {
 
-    private final UserRepository userRepository;
     private final AccommodationRepository accommodationRepository;
 
     public Accommodation saveAccommodation(AccommodationRequestDto accommodationRequestDto, AuthUser loginUser) {
-        User owner = userRepository.findById(loginUser.getId()).get();
-        VerificationUtils.verifyOwnerPermission(loginUser, owner.getId());
-        Accommodation accommodation = accommodationRequestDto.toEntity(owner);
+        VerificationUtils.verifyOwnerPermission(loginUser, loginUser.getId());
+        Accommodation accommodation = accommodationRequestDto.toEntity(loginUser.getId());
         validateDuplicatedAccommodation(accommodation);
         return accommodationRepository.save(accommodation);
     }

--- a/src/main/java/com/project/jagoga/accommodation/presentation/dto/AccommodationRequestDto.java
+++ b/src/main/java/com/project/jagoga/accommodation/presentation/dto/AccommodationRequestDto.java
@@ -3,14 +3,12 @@ package com.project.jagoga.accommodation.presentation.dto;
 import com.project.jagoga.accommodation.domain.Accommodation;
 import com.project.jagoga.accommodation.domain.AccommodationType;
 import com.project.jagoga.accommodation.domain.address.City;
-import com.project.jagoga.user.domain.User;
-import lombok.Builder;
-import lombok.Getter;
-import org.hibernate.validator.constraints.Length;
-
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Builder
@@ -19,8 +17,6 @@ public class AccommodationRequestDto {
     @NotBlank(message = "숙소 이름은 빈 칸일 수 없습니다.")
     @Length(max = 20, message = "이름은 20자 이내로 입력하세요.")
     private String accommodationName;
-
-    private Long ownerId;
 
     @NotBlank(message = "형식이 맞지 않습니다")
     @Pattern(regexp = "\\d{3}-\\d{4}-\\d{4}")
@@ -38,11 +34,10 @@ public class AccommodationRequestDto {
     protected AccommodationRequestDto() {
     }
 
-    public AccommodationRequestDto(String accommodationName, Long ownerId, String phoneNumber,
+    public AccommodationRequestDto(String accommodationName, String phoneNumber,
                                    City city, AccommodationType accommodationType, String description,
                                    String information) {
         this.accommodationName = accommodationName;
-        this.ownerId = ownerId;
         this.phoneNumber = phoneNumber;
         this.city = city;
         this.accommodationType = accommodationType;
@@ -50,10 +45,10 @@ public class AccommodationRequestDto {
         this.information = information;
     }
 
-    public Accommodation toEntity(User owner) {
+    public Accommodation toEntity(long ownerId) {
         return Accommodation.builder()
             .accommodationName(accommodationName)
-            .ownerId(owner.getId())
+            .ownerId(ownerId)
             .phoneNumber(phoneNumber)
             .cityId(city.getId())
             .accommodationType(accommodationType)


### PR DESCRIPTION
## 상세내용
Accommodation 생성을 요청하는 AccommodationRequestDto의 **ownerId 필드를 삭제하려고 합니다.**
(현재 Accommodation 생성시마다  User 조회 쿼리가 호출됩니다.)

Accommodation 생성시 서비스 레이어에서 현재 로그인한 유저의 id 정보를 ownerId에 할당합니다.

```
 {
    "accommodationName" : String,
    "ownerId": Long,
    "phoneNumber" : String,
    "city" : {
        "id": Long,
        "name" : String
    },
    "accommodationType" : String,
    "description" : String,
    "information" : String
}
```